### PR TITLE
Fix navigation for home/browse transitions

### DIFF
--- a/MyLoginApp/app/(tabs)/transition-screen.tsx
+++ b/MyLoginApp/app/(tabs)/transition-screen.tsx
@@ -7,14 +7,17 @@ import BrowseScreen from "./browse"; // Browse tab screen
 
 type Params = {
   target: "home" | "browse";
+  from?: "home" | "browse";
 };
 
 export default function TransitionScreen() {
   const router = useRouter();
   const pathname = usePathname();
-  const { target } = useLocalSearchParams<Params>();
+  const { target, from } = useLocalSearchParams<Params>();
 
   const [current] = useState<"home" | "browse">(() => {
+    if (from === "browse") return "browse";
+    if (from === "home") return "home";
     if (pathname.includes("browse")) return "browse";
     return "home";
   });
@@ -28,7 +31,8 @@ export default function TransitionScreen() {
 
   useEffect(() => {
     const timer = setTimeout(() => {
-      router.replace("/(tabs)/" + target);
+      const path = target === "home" ? "/(tabs)" : "/(tabs)/" + target;
+      router.replace(path);
     }, 300);
     return () => clearTimeout(timer);
   }, [target]);

--- a/MyLoginApp/components/BottomNav.tsx
+++ b/MyLoginApp/components/BottomNav.tsx
@@ -11,6 +11,10 @@ export default function BottomNav() {
   const router = useRouter();
   const pathname = usePathname();
 
+  const currentTab: "home" | "browse" = pathname.includes("browse")
+    ? "browse"
+    : "home";
+
   const tabs = [
     { name: "Home", icon: "home", target: "home", path: "/(tabs)" },
     { name: "Browse", icon: "search", target: "browse", path: "/(tabs)/browse" },
@@ -31,7 +35,7 @@ export default function BottomNav() {
               Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
               router.push({
                 pathname: "/transition-screen",
-                params: { target: tab.target },
+                params: { target: tab.target, from: currentTab },
               });
             }}
           >

--- a/MyLoginApp/screens/TransitionScreen.tsx
+++ b/MyLoginApp/screens/TransitionScreen.tsx
@@ -7,14 +7,17 @@ import BrowseScreen from "../app/(tabs)/browse"; // Browse tab screen
 
 type Params = {
   target: "home" | "browse";
+  from?: "home" | "browse";
 };
 
 export default function TransitionScreen() {
   const router = useRouter();
   const pathname = usePathname();
-  const { target } = useLocalSearchParams<Params>();
+  const { target, from } = useLocalSearchParams<Params>();
 
   const [current] = useState<"home" | "browse">(() => {
+    if (from === "browse") return "browse";
+    if (from === "home") return "home";
     if (pathname.includes("browse")) return "browse";
     return "home";
   });
@@ -28,7 +31,8 @@ export default function TransitionScreen() {
 
   useEffect(() => {
     const timer = setTimeout(() => {
-      router.replace("/(tabs)/" + target);
+      const path = target === "home" ? "/(tabs)" : "/(tabs)/" + target;
+      router.replace(path);
     }, 300);
     return () => clearTimeout(timer);
   }, [target]);


### PR DESCRIPTION
## Summary
- track the originating tab when opening the transition screen
- fix redirection path so navigating to the home tab works

## Testing
- `npm run lint` *(fails: "lint" is not an expo command)*
- `npm test --silent` in `frontend` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_688947c49ecc832baee38b9324620939