### PR TITLE
Fix navigation for home/browse transitions

### DIFF
--- a/MyLoginApp/app/(tabs)/transition-screen.tsx
+++ b/MyLoginApp/app/(tabs)/transition-screen.tsx
@@ -4,31 +4,35 @@ import { useLocalSearchParams, usePathname, useRouter } from "expo-router";
 import TransitionWrapper from "../../components/TransitionWrapper";
 import HomeScreen from "./index"; // Home tab screen
 import BrowseScreen from "./browse"; // Browse tab screen
+import ReservesScreen from "./reserves"; // Cart tab screen
+
+type Tab = "home" | "browse" | "reserves";
 
 type Params = {
-  target: "home" | "browse";
+  target: Tab;
+  from?: Tab;
 };
 
 export default function TransitionScreen() {
   const router = useRouter();
   const pathname = usePathname();
-  const { target } = useLocalSearchParams<Params>();
+  const { target, from } = useLocalSearchParams<Params>();
 
-  const [current] = useState<"home" | "browse">(() => {
+  const [current] = useState<Tab>(() => {
+    if (from === "browse" || from === "home" || from === "reserves") return from;
     if (pathname.includes("browse")) return "browse";
+    if (pathname.includes("reserves")) return "reserves";
     return "home";
   });
 
+  const pages: Tab[] = ["home", "browse", "reserves"];
   const direction: "left" | "right" =
-    current === "home" && target === "browse"
-      ? "left"
-      : current === "browse" && target === "home"
-      ? "right"
-      : "left";
+    pages.indexOf(target) > pages.indexOf(current) ? "left" : "right";
 
   useEffect(() => {
     const timer = setTimeout(() => {
-      router.replace("/(tabs)/" + target);
+      const path = target === "home" ? "/(tabs)" : "/(tabs)/" + target;
+      router.replace(path);
     }, 300);
     return () => clearTimeout(timer);
   }, [target]);
@@ -39,8 +43,10 @@ export default function TransitionScreen() {
       <TransitionWrapper direction={direction} isEntering={false}>
         {current === "home" ? (
           <HomeScreen skipAnimation />
-        ) : (
+        ) : current === "browse" ? (
           <BrowseScreen skipAnimation />
+        ) : (
+          <ReservesScreen skipAnimation />
         )}
       </TransitionWrapper>
 
@@ -48,8 +54,10 @@ export default function TransitionScreen() {
       <TransitionWrapper direction={direction} isEntering>
         {target === "home" ? (
           <HomeScreen skipAnimation />
-        ) : (
+        ) : target === "browse" ? (
           <BrowseScreen skipAnimation />
+        ) : (
+          <ReservesScreen skipAnimation />
         )}
       </TransitionWrapper>
     </View>

--- a/MyLoginApp/components/BottomNav.tsx
+++ b/MyLoginApp/components/BottomNav.tsx
@@ -11,6 +11,12 @@ export default function BottomNav() {
   const router = useRouter();
   const pathname = usePathname();
 
+  const currentTab: "home" | "browse" | "reserves" = pathname.includes("browse")
+    ? "browse"
+    : pathname.includes("reserves")
+    ? "reserves"
+    : "home";
+
   const tabs = [
     { name: "Home", icon: "home", target: "home", path: "/(tabs)" },
     { name: "Browse", icon: "search", target: "browse", path: "/(tabs)/browse" },
@@ -31,7 +37,7 @@ export default function BottomNav() {
               Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
               router.push({
                 pathname: "/transition-screen",
-                params: { target: tab.target },
+                params: { target: tab.target, from: currentTab },
               });
             }}
           >

--- a/MyLoginApp/screens/ReservesScreen.tsx
+++ b/MyLoginApp/screens/ReservesScreen.tsx
@@ -10,7 +10,11 @@ import {
 import { Ionicons } from "@expo/vector-icons";
 import BottomNav from "../components/BottomNav";
 
-export default function ReservesScreen() {
+type Props = {
+  skipAnimation?: boolean;
+};
+
+export default function ReservesScreen({ skipAnimation }: Props) {
   return (
     <View style={styles.container}>
       <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>

--- a/MyLoginApp/screens/TransitionScreen.tsx
+++ b/MyLoginApp/screens/TransitionScreen.tsx
@@ -4,31 +4,35 @@ import { useLocalSearchParams, usePathname, useRouter } from "expo-router";
 import TransitionWrapper from "../components/TransitionWrapper";
 import HomeScreen from "../app/(tabs)/index"; // Home tab screen
 import BrowseScreen from "../app/(tabs)/browse"; // Browse tab screen
+import ReservesScreen from "../app/(tabs)/reserves"; // Cart tab screen
+
+type Tab = "home" | "browse" | "reserves";
 
 type Params = {
-  target: "home" | "browse";
+  target: Tab;
+  from?: Tab;
 };
 
 export default function TransitionScreen() {
   const router = useRouter();
   const pathname = usePathname();
-  const { target } = useLocalSearchParams<Params>();
+  const { target, from } = useLocalSearchParams<Params>();
 
-  const [current] = useState<"home" | "browse">(() => {
+  const [current] = useState<Tab>(() => {
+    if (from === "browse" || from === "home" || from === "reserves") return from;
     if (pathname.includes("browse")) return "browse";
+    if (pathname.includes("reserves")) return "reserves";
     return "home";
   });
 
+  const pages: Tab[] = ["home", "browse", "reserves"];
   const direction: "left" | "right" =
-    current === "home" && target === "browse"
-      ? "left"
-      : current === "browse" && target === "home"
-      ? "right"
-      : "left";
+    pages.indexOf(target) > pages.indexOf(current) ? "left" : "right";
 
   useEffect(() => {
     const timer = setTimeout(() => {
-      router.replace("/(tabs)/" + target);
+      const path = target === "home" ? "/(tabs)" : "/(tabs)/" + target;
+      router.replace(path);
     }, 300);
     return () => clearTimeout(timer);
   }, [target]);
@@ -39,8 +43,10 @@ export default function TransitionScreen() {
       <TransitionWrapper direction={direction} isEntering={false}>
         {current === "home" ? (
           <HomeScreen skipAnimation />
-        ) : (
+        ) : current === "browse" ? (
           <BrowseScreen skipAnimation />
+        ) : (
+          <ReservesScreen skipAnimation />
         )}
       </TransitionWrapper>
 
@@ -48,8 +54,10 @@ export default function TransitionScreen() {
       <TransitionWrapper direction={direction} isEntering>
         {target === "home" ? (
           <HomeScreen skipAnimation />
-        ) : (
+        ) : target === "browse" ? (
           <BrowseScreen skipAnimation />
+        ) : (
+          <ReservesScreen skipAnimation />
         )}
       </TransitionWrapper>
     </View>


### PR DESCRIPTION
## Summary
- track the originating tab when opening the transition screen
- fix redirection path so navigating to the home tab works
- extend transition logic for the cart tab

## Testing
- `npm test --silent` in `frontend` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_688947c49ecc832baee38b9324620939