### PR TITLE
Fix header and bottom navigation

### DIFF
--- a/MyLoginApp/components/BottomNav.tsx
+++ b/MyLoginApp/components/BottomNav.tsx
@@ -60,6 +60,10 @@ export default function BottomNav() {
 
 const styles = StyleSheet.create({
   bottomNav: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    bottom: 0,
     flexDirection: "row",
     justifyContent: "space-around",
     alignItems: "flex-end",
@@ -67,7 +71,6 @@ const styles = StyleSheet.create({
     borderTopWidth: 1,
     borderColor: "#eee",
     backgroundColor: "#fff",
-    marginBottom: 20,
   },
   iconButton: {
     alignItems: "center",

--- a/MyLoginApp/screens/BrowseScreen.tsx
+++ b/MyLoginApp/screens/BrowseScreen.tsx
@@ -48,7 +48,14 @@ export default function BrowseScreen({ skipAnimation, hideHeader, hideNav }: Pro
   }));
 
   return (
-    <Animated.View style={[styles.container, animatedStyle]}>
+    <Animated.View
+      style={[
+        styles.container,
+        animatedStyle,
+        hideHeader && { paddingTop: 0 },
+        hideNav && { paddingBottom: 0 },
+      ]}
+    >
       {!hideHeader && (
         <>
           <SearchBar />
@@ -84,6 +91,7 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: "#fff",
     paddingTop: 50,
+    paddingBottom: 70,
   },
   content: {
     flex: 1,

--- a/MyLoginApp/screens/HomeScreen.tsx
+++ b/MyLoginApp/screens/HomeScreen.tsx
@@ -78,7 +78,14 @@ export default function HomeScreen({ skipAnimation, hideHeader, hideNav }: Props
   };
 
   return (
-    <Animated.View style={[styles.container, animatedStyle]}>
+    <Animated.View
+      style={[
+        styles.container,
+        animatedStyle,
+        hideHeader && { paddingTop: 0 },
+        hideNav && { paddingBottom: 0 },
+      ]}
+    >
       {!hideHeader && (
         <>
           <SearchBar />
@@ -99,5 +106,6 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: "#fff",
     paddingTop: 50,
+    paddingBottom: 70,
   },
 });

--- a/MyLoginApp/screens/ReservesScreen.tsx
+++ b/MyLoginApp/screens/ReservesScreen.tsx
@@ -17,7 +17,10 @@ type Props = {
 
 export default function ReservesScreen({ skipAnimation, hideNav }: Props) {
   return (
-    <View style={styles.container}>
+    <View style={[
+      styles.container,
+      hideNav && { paddingBottom: 0 },
+    ]}>
       <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
         <Text style={styles.sectionTitle}>Reserves</Text>
 
@@ -82,6 +85,7 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: "#fff",
     paddingTop: 50,
+    paddingBottom: 70,
   },
   content: {
     flex: 1,

--- a/MyLoginApp/screens/TransitionScreen.tsx
+++ b/MyLoginApp/screens/TransitionScreen.tsx
@@ -1,5 +1,8 @@
 import React, { useEffect, useState } from "react";
 import { View } from "react-native";
+import SearchBar from "../components/SearchBar";
+import CategoryFilters from "../components/CategoryFilters";
+import BottomNav from "../components/BottomNav";
 import { useLocalSearchParams, usePathname, useRouter } from "expo-router";
 import TransitionWrapper from "../components/TransitionWrapper";
 import HomeScreen from "../app/(tabs)/index"; // Home tab screen
@@ -29,6 +32,8 @@ export default function TransitionScreen() {
   const direction: "left" | "right" =
     pages.indexOf(target) > pages.indexOf(current) ? "left" : "right";
 
+  const showHeader = current !== "reserves" && target !== "reserves";
+
   useEffect(() => {
     const timer = setTimeout(() => {
       const path = target === "home" ? "/(tabs)" : "/(tabs)/" + target;
@@ -39,27 +44,36 @@ export default function TransitionScreen() {
 
   return (
     <View style={{ flex: 1 }}>
+      {showHeader && (
+        <View style={{ paddingTop: 50 }}>
+          <SearchBar />
+          <CategoryFilters />
+        </View>
+      )}
+
       {/* Exit current screen */}
       <TransitionWrapper direction={direction} isEntering={false}>
         {current === "home" ? (
-          <HomeScreen skipAnimation />
+          <HomeScreen skipAnimation hideHeader hideNav />
         ) : current === "browse" ? (
-          <BrowseScreen skipAnimation />
+          <BrowseScreen skipAnimation hideHeader hideNav />
         ) : (
-          <ReservesScreen skipAnimation />
+          <ReservesScreen skipAnimation hideNav />
         )}
       </TransitionWrapper>
 
       {/* Enter new screen */}
       <TransitionWrapper direction={direction} isEntering>
         {target === "home" ? (
-          <HomeScreen skipAnimation />
+          <HomeScreen skipAnimation hideHeader hideNav />
         ) : target === "browse" ? (
-          <BrowseScreen skipAnimation />
+          <BrowseScreen skipAnimation hideHeader hideNav />
         ) : (
-          <ReservesScreen skipAnimation />
+          <ReservesScreen skipAnimation hideNav />
         )}
       </TransitionWrapper>
+
+      <BottomNav />
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- keep bottom navigation fixed at the bottom
- keep search bar and categories fixed when switching between Home and Browse
- adjust screen padding when headers or nav are hidden

## Testing
- `npm run lint` *(fails: "expo lint" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68898c4ba8a4832b9e4932a6164fb9ec